### PR TITLE
usando load encoder no classificador

### DIFF
--- a/nbs/Laboratory.ipynb
+++ b/nbs/Laboratory.ipynb
@@ -593,7 +593,8 @@
    },
    "outputs": [],
    "source": [
-    "clf = text_classifier_learner(data_clas, AWD_LSTM, drop_mult=0.5, pretrained=False)"
+    "clf = text_classifier_learner(data_clas, AWD_LSTM, drop_mult=0.5, pretrained=False)\n",
+    "clf.load_encoder('pretrained_encoder')"
    ]
   },
   {
@@ -709,7 +710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Justificativa

O encoder do language_model_learner não está sendo utilizado no text_classifier_learner. 

Ele foi salvo na linha:

```
learn.save_encoder('pretrained_encoder')
```

Mas no text_classifier_learner ele não foi carregado.

Rodei o código com o load e o resultado foi melhor. O principal foi o assunto "Assistência ao PNAE".

**Antes**

![image](https://user-images.githubusercontent.com/1680085/59555779-14498000-8f8e-11e9-86c9-61f2844ceb5f.png)


**Depois**

![image](https://user-images.githubusercontent.com/1680085/59554932-40aacf80-8f81-11e9-8239-f0e0f05a9db4.png)

### Alteração

Acrescentado o load_encoder 'pretrained_encoder' salvo anteriormente para ser usado no text_classifier_learner



